### PR TITLE
stm32g4: Add EXTI support

### DIFF
--- a/include/libopencm3/stm32/exti.h
+++ b/include/libopencm3/stm32/exti.h
@@ -42,6 +42,8 @@
 #       include <libopencm3/stm32/l4/exti.h>
 #elif defined(STM32G0)
 #       include <libopencm3/stm32/g0/exti.h>
+#elif defined(STM32G4)
+#       include <libopencm3/stm32/g4/exti.h>
 #elif defined(STM32H7)
 #       include <libopencm3/stm32/h7/exti.h>
 #else

--- a/include/libopencm3/stm32/g4/exti.h
+++ b/include/libopencm3/stm32/g4/exti.h
@@ -1,0 +1,59 @@
+/** @defgroup exti_defines EXTI Defines
+ *
+ * @brief <b>Defined Constants and Types for the STM32G4xx External Interrupts
+ * </b>
+ *
+ * @ingroup STM32G4xx_defines
+ *
+ * @author @htmlonly &copy; @endhtmlonly 2023
+ * Benedikt Spranger <b.spranger@linutronix.de>
+ *
+ * @version 1.0.0
+ *
+ * @date 19 February 2023
+ *
+ * LGPL License Terms @ref lgpl_license
+ */
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2023 Benedikt Spranger <b.spranger@linutronix.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBOPENCM3_EXTI_H
+#define LIBOPENCM3_EXTI_H
+/**@{*/
+
+#include <libopencm3/stm32/common/exti_common_all.h>
+#include <libopencm3/stm32/common/exti_common_v1.h>
+
+/* --- EXTI registers ------------------------------------------------------ */
+#define EXTI_IMR1			EXTI_IMR
+#define EXTI_EMR1			EXTI_EMR
+#define EXTI_RTSR1			EXTI_RTSR
+#define EXTI_FTSR1			EXTI_FTSR
+#define EXTI_SWIER1			EXTI_SWIER
+#define EXTI_PR1			EXTI_PR
+
+#define EXTI_IMR2			MMIO32(EXTI_BASE + 0x20)
+#define EXTI_EMR2			MMIO32(EXTI_BASE + 0x24)
+#define EXTI_RTSR2			MMIO32(EXTI_BASE + 0x28)
+#define EXTI_FTSR2			MMIO32(EXTI_BASE + 0x2C)
+#define EXTI_SWIER2			MMIO32(EXTI_BASE + 0x30)
+#define EXTI_PR2			MMIO32(EXTI_BASE + 0x34)
+
+/**@}*/
+#endif

--- a/lib/stm32/g4/Makefile
+++ b/lib/stm32/g4/Makefile
@@ -42,6 +42,7 @@ OBJS += crc_common_all.o crc_v2.o
 OBJS += dac_common_all.o dac_common_v2.o
 OBJS += dma_common_l1f013.o
 OBJS += dmamux.o
+OBJS += exti_common_all.o
 OBJS += fdcan.o fdcan_common.o
 OBJS += flash.o flash_common_all.o flash_common_f.o flash_common_idcache.o
 OBJS += gpio_common_all.o gpio_common_f0234.o


### PR DESCRIPTION
The STM32G4xx series contain two regular EXTI v1 blocks; one at offset 0x00, the other at offset 0x20.
Add support for EXTI.